### PR TITLE
Straightening out the babel environment mess.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-  "extends": "react-native/packager/react-packager/rn-babelrc.json",
-  "plugins": [
-    "transform-runtime"
-  ]
-}

--- a/Tests/Compiler.js
+++ b/Tests/Compiler.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var babel = require('babel-core');
 var origJs = require.extensions['.js'];
+require('babel-polyfill')
 
 require.extensions['.js'] = function (module, fileName) {
   var output;
@@ -19,7 +20,8 @@ require.extensions['.js'] = function (module, fileName) {
   }
   var src = fs.readFileSync(fileName, 'utf8');
   output = babel.transform(src, {
-    filename: fileName
+    filename: fileName,
+    'presets': ['react-native']
   }).code;
 
   return module._compile(output, fileName);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",
-    "babel-plugin-transform-runtime": "^6.6.0",
     "chai": "^3.5.0",
     "chai-immutable": "^1.5.3",
     "deep-freeze": "0.0.1",


### PR DESCRIPTION
This fixes up the strangeness with the missing 'requires' stuff.

Basically 2 changes.

1.  Get rid of the custom .babelrc.  Everything we need is in the default one.
2.  Since Compiler.js uses its own built-in babelrc, we make sure we use the right preset and include babel-polyfill for generator support. (sigh)

Make sure you `rm -rf node_modules` and `npm i` to ensure everything is sane.



