### PR TITLE
Separates redux-persist state transformations to its own file.

### DIFF
--- a/App/Reducers/CreateReducer.js
+++ b/App/Reducers/CreateReducer.js
@@ -1,5 +1,3 @@
-import Immutable from 'seamless-immutable'
-
 /**
   Creates a reducer.
   @param {string} initialState - The initial state for this reducer.
@@ -9,11 +7,5 @@ import Immutable from 'seamless-immutable'
 export default (initialState = null, handlers = {}) => (state = initialState, action) => {
   if (!action && !action.type) return state
   const handler = handlers[action.type]
-
-  // Check to see if the state is already Immutable
-  if (state && typeof state.asMutable === 'function') {
-    return handler && handler(state, action) || state
-  } else {
-    return handler && handler(Immutable(state), action) || Immutable(state)
-  }
+  return handler && handler(state, action) || state
 }

--- a/App/Sagas/StartupSaga.js
+++ b/App/Sagas/StartupSaga.js
@@ -1,11 +1,16 @@
-import { take, put } from 'redux-saga/effects'
+import { take, put, select } from 'redux-saga/effects'
 import Types from '../Actions/Types'
 import Actions from '../Actions/Creators'
+import R from 'ramda'
 
 // process STARTUP actions
 export function * watchStartup () {
   while (true) {
     yield take(Types.STARTUP)
-    yield put(Actions.requestTemperature('San Francisco'))
+    const temp = yield select((state) => state.weather.temperature)
+    // only fetch new temps when we don't have one yet
+    if (!R.is(Number, temp)) {
+      yield put(Actions.requestTemperature('San Francisco'))
+    }
   }
 }

--- a/App/Store/ImmutablePersistenceTransform.js
+++ b/App/Store/ImmutablePersistenceTransform.js
@@ -1,0 +1,36 @@
+import R from 'ramda'
+import Immutable from 'seamless-immutable'
+
+// is this object already Immutable?
+const isImmutable = R.has('asMutable')
+
+// change this Immutable object into a JS object
+const convertToJs = (state) => state.asMutable({deep: true})
+
+// optionally convert this object into a JS object if it is Immutable
+const fromImmutable = R.when(isImmutable, convertToJs)
+
+// convert this JS object into an Immutable object
+const toImmutable = (raw) => Immutable(raw)
+
+// the transform interface that redux-persist is expecting
+export default {
+  out: (state) => {
+    // console.log({ retrieving: state })
+    // --- HACKZORZ ---
+    // Attach a empty-ass function to the object called `mergeDeep`.
+    // This tricks redux-persist into just placing our Immutable object into the state tree
+    // instead of trying to convert it to a POJO
+    // https://github.com/rt2zz/redux-persist/blob/master/src/autoRehydrate.js#L55
+    //
+    // Another equal terrifying option would be to try to pass their other check
+    // which is lodash isPlainObject.
+    // --- END HACKZORZ ---
+    state.mergeDeep = R.identity
+    return toImmutable(state)
+  },
+  in: (raw) => {
+    // console.log({ storing: raw })
+    return fromImmutable(raw)
+  }
+}

--- a/App/Store/Store.js
+++ b/App/Store/Store.js
@@ -7,14 +7,15 @@ import Config from '../Config/DebugSettings'
 import sagaMiddleware from 'redux-saga'
 import sagas from '../Sagas/'
 import R from 'ramda'
+import immutablePersistenceTransform from './ImmutablePersistenceTransform'
 
 // the logger master switch
 const USE_LOGGING = Config.reduxLogging
 // silence these saga-based messages
-const BLACKLIST = ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED']
+const SAGA_LOGGING_BLACKLIST = ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED', 'persist/REHYDRATE']
 // creat the logger
 const logger = createLogger({
-  predicate: (getState, { type }) => USE_LOGGING && R.not(R.contains(type, BLACKLIST))
+  predicate: (getState, { type }) => USE_LOGGING && R.not(R.contains(type, SAGA_LOGGING_BLACKLIST))
 })
 
 // a function which can create our store and auto-persist the data
@@ -31,7 +32,8 @@ export default () => {
   if (Config.reduxPersist) {
     persistStore(store, {
       storage: AsyncStorage,
-      blacklist: persistentStoreBlacklist
+      blacklist: persistentStoreBlacklist,
+      transforms: [immutablePersistenceTransform]
     })
   }
 


### PR DESCRIPTION
This:

* promotes the seamless-immutable conversion to its own transform file.
* silences extra chatter in the logger caused by redux-persist
* only triggers the weather check on startup if we don't have one yet
