### PR TITLE
Features/i18n

### DIFF
--- a/App/Containers/AllComponentsScreen.js
+++ b/App/Containers/AllComponentsScreen.js
@@ -10,6 +10,9 @@ import Routes from '../Navigation/Routes'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import Animatable from 'react-native-animatable'
 
+// I18n
+import I18n from '../I18n/I18n.js'
+
 export default class AllComponentsScreen extends React.Component {
 
   constructor (props) {
@@ -45,7 +48,7 @@ export default class AllComponentsScreen extends React.Component {
       <View style={styles.loginBox}>
         <TouchableOpacity onPress={this.handlePressLogin}>
           <View style={styles.loginButton}>
-            <Text style={styles.loginText}>Sign In</Text>
+            <Text style={styles.loginText}>{I18n.t('signIn')}</Text>
           </View>
         </TouchableOpacity>
       </View>
@@ -57,7 +60,7 @@ export default class AllComponentsScreen extends React.Component {
       <View style={styles.loginBox}>
         <TouchableOpacity onPress={this.handlePressLogout}>
           <View style={styles.loginButton}>
-            <Text style={styles.loginText}>Log out</Text>
+            <Text style={styles.loginText}>{I18n.t('logOut')}</Text>
           </View>
         </TouchableOpacity>
       </View>
@@ -68,18 +71,18 @@ export default class AllComponentsScreen extends React.Component {
     const { loggedIn, temperature, city } = this.props
     return (
       <ScrollView style={styles.screenContainer}>
-        <Text style={styles.componentLabel}>Login/Logout Redux + Sagas Example</Text>
+        <Text style={styles.componentLabel}>{I18n.t('loginLogoutExampleTitle')}</Text>
         {loggedIn ? this.renderLogoutButton() : this.renderLoginButton()}
-        <Text style={styles.componentLabel}>Progressive Image Component</Text>
+        <Text style={styles.componentLabel}>{I18n.t('progressiveImageComponent')}</Text>
         <ProgressiveImage
           style={styles.progressiveImage}
           defaultSource={Images.logo}
           source='https://upload.wikimedia.org/wikipedia/commons/c/cc/ESC_large_ISS022_ISS022-E-11387-edit_01.JPG'
           thumbnail='http://i.imgur.com/eVAFUhj.png'
         />
-        <Text style={styles.componentLabel}>Http Client: {city}</Text>
+        <Text style={styles.componentLabel}>{I18n.t('httpClient')}: {city}</Text>
         <Text style={styles.temperature}>{temperature && `${temperature} F`}</Text>
-        <Text style={styles.componentLabel}>RN Vector Icons</Text>
+        <Text style={styles.componentLabel}>{I18n.t('rnVectorIcons')}</Text>
         <View style={styles.groupContainer}>
           <Icon name='rocket' size={Metrics.icons.medium} color={Colors.error} />
           <Icon name='send' size={Metrics.icons.medium} color={Colors.error} />
@@ -89,12 +92,12 @@ export default class AllComponentsScreen extends React.Component {
         </View>
         <View style={styles.groupContainer}>
           <Icon.Button name='facebook' style={styles.facebookButton} backgroundColor={Colors.facebook} onPress={() => window.alert('Facebook')}>
-            Login with Facebook
+            {I18n.t('loginWithFacebook')}
           </Icon.Button>
         </View>
-        <Text style={styles.componentLabel}>RN Animatable</Text>
+        <Text style={styles.componentLabel}>{I18n.t('rnAnimatable')}</Text>
         <View style={styles.groupContainer}>
-          <Animatable.Text animation='fadeIn' iterationCount='infinite' direction='alternate'>RN Animatable</Animatable.Text>
+          <Animatable.Text animation='fadeIn' iterationCount='infinite' direction='alternate'>{I18n.t('rnAnimatable')}</Animatable.Text>
           <Animatable.Image animation='pulse' iterationCount='infinite' source={Images.logo} />
           <Animatable.View animation='jello' iterationCount='infinite'>
             <Icon name='cab' size={Metrics.icons.medium} />

--- a/App/Containers/AllComponentsScreen.js
+++ b/App/Containers/AllComponentsScreen.js
@@ -81,7 +81,7 @@ export default class AllComponentsScreen extends React.Component {
           thumbnail='http://i.imgur.com/eVAFUhj.png'
         />
         <Text style={styles.componentLabel}>{I18n.t('httpClient')}: {city}</Text>
-        <Text style={styles.temperature}>{temperature && `${temperature} F`}</Text>
+        <Text style={styles.temperature}>{temperature && `${temperature} ${I18n.t('tempIndicator')}`}</Text>
         <Text style={styles.componentLabel}>{I18n.t('rnVectorIcons')}</Text>
         <View style={styles.groupContainer}>
           <Icon name='rocket' size={Metrics.icons.medium} color={Colors.error} />

--- a/App/Containers/LoginScreen.js
+++ b/App/Containers/LoginScreen.js
@@ -15,6 +15,9 @@ import Styles from '../Styles/LoginScreenStyle'
 import Actions from '../Actions/Creators'
 import {Images, Metrics} from '../Themes'
 
+// I18n
+import I18n from '../I18n/I18n.js'
+
 class LoginScreen extends Component {
 
   constructor (props) {
@@ -53,7 +56,7 @@ class LoginScreen extends Component {
 
   // Method that runs when you tap the right nav bar button
   tapForgotPassword () {
-    Alert.alert('Forgot Password')
+    Alert.alert(I18n.t('forgotPassword'))
   }
 
   componentWillUnmount () {
@@ -111,7 +114,7 @@ class LoginScreen extends Component {
         <Image source={Images.logo} style={[Styles.topLogo, this.state.topLogo]}/>
         <View style={Styles.form}>
           <View style={Styles.row}>
-            <Text style={Styles.rowLabel}>Username</Text>
+            <Text style={Styles.rowLabel}>{I18n.t('username')}</Text>
             <TextInput
               ref='username'
               style={textInputStyle}
@@ -120,11 +123,11 @@ class LoginScreen extends Component {
               keyboardType='default'
               returnKeyType='search'
               onChangeText={this.handleChangeUsername}
-              placeholder='Username' />
+              placeholder={I18n.t('username')} />
           </View>
 
           <View style={Styles.row}>
-            <Text style={Styles.rowLabel}>Password</Text>
+            <Text style={Styles.rowLabel}>{I18n.t('password')}</Text>
             <TextInput
               ref='password'
               style={textInputStyle}
@@ -134,18 +137,18 @@ class LoginScreen extends Component {
               returnKeyType='search'
               secureTextEntry
               onChangeText={this.handleChangePassword}
-              placeholder='Password' />
+              placeholder={I18n.t('password')} />
           </View>
 
           <View style={[Styles.loginRow]}>
             <TouchableOpacity style={Styles.loginButtonWrapper} onPress={this.handlePressLogin}>
               <View style={Styles.loginButton}>
-                <Text style={Styles.loginText}>Sign In</Text>
+                <Text style={Styles.loginText}>{I18n.t('signIn')}</Text>
               </View>
             </TouchableOpacity>
             <TouchableOpacity style={Styles.loginButtonWrapper} onPress={this.handlePressCancel}>
               <View style={Styles.loginButton}>
-                <Text style={Styles.loginText}>Cancel</Text>
+                <Text style={Styles.loginText}>{I18n.t('cancel')}</Text>
               </View>
             </TouchableOpacity>
           </View>

--- a/App/I18n/I18n.js
+++ b/App/I18n/I18n.js
@@ -19,7 +19,8 @@ I18n.translations = {
     password: 'Password',
     cancel: 'Cancel',
     welcome: 'Welcome',
-    login: 'Login'
+    login: 'Login',
+    tempIndicator: 'F'
   },
   fr: {
     signIn: 'Se connecter',
@@ -35,7 +36,8 @@ I18n.translations = {
     password: 'Mot de passe',
     cancel: 'Annuler',
     welcome: 'Bienvenue',
-    login: 'S\'identifier'
+    login: 'S\'identifier',
+    tempIndicator: 'C'
   }
 }
 

--- a/App/I18n/I18n.js
+++ b/App/I18n/I18n.js
@@ -1,0 +1,42 @@
+import I18n from 'react-native-i18n'
+
+// Enable fallbacks if you want `en-US` and `en-GB` to fallback to `en`
+I18n.fallbacks = true
+
+// All translations for the app go here:
+I18n.translations = {
+  en: {
+    signIn: 'Sign In',
+    logOut: 'Log Out',
+    loginLogoutExampleTitle: 'Login/Logout Redux + Sagas Example',
+    progressiveImageComponent: 'Progressive Image Component',
+    httpClient: 'Http Client',
+    rnVectorIcons: 'RN Vector Icons',
+    loginWithFacebook: 'Login with Facebook',
+    rnAnimatable: 'RN Animatable',
+    forgotPassword: 'Forgot Password',
+    username: 'Username',
+    password: 'Password',
+    cancel: 'Cancel',
+    welcome: 'Welcome',
+    login: 'Login'
+  },
+  fr: {
+    signIn: 'Se connecter',
+    logOut: 'Se déconnecter',
+    loginLogoutExampleTitle: 'Connexion / Déconnexion Redux + Sagas Exemple',
+    progressiveImageComponent: 'Composant Image Progressive',
+    httpClient: 'Http Client',
+    rnVectorIcons: 'RN icônes vectorielles',
+    loginWithFacebook: 'Se connecter avec Facebook',
+    rnAnimatable: 'RN Animatable',
+    forgotPassword: 'Mot de passe oublié',
+    username: 'Nom d\'utilisateur',
+    password: 'Mot de passe',
+    cancel: 'Annuler',
+    welcome: 'Bienvenue',
+    login: 'S\'identifier'
+  }
+}
+
+export default I18n

--- a/App/Navigation/NavButtons.js
+++ b/App/Navigation/NavButtons.js
@@ -3,6 +3,9 @@ import styles from '../Styles/NavigationStyle'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import { Colors, Metrics } from '../Themes'
 
+// I18n
+import I18n from '../I18n/I18n.js'
+
 export default {
 
   backButton (onPressFunction) {
@@ -20,7 +23,7 @@ export default {
   forgotPasswordButton (onPressFunction) {
     return (
       <TouchableOpacity onPress={onPressFunction}>
-        <Text style={styles.navButtonText}>Forgot Password</Text>
+        <Text style={styles.navButtonText}>{I18n.t('forgotPassword')}</Text>
       </TouchableOpacity>
     )
   }

--- a/App/Navigation/Routes.js
+++ b/App/Navigation/Routes.js
@@ -1,5 +1,8 @@
 import { Transitions } from '../Themes/'
 
+// I18n
+import I18n from '../I18n/I18n.js'
+
 export default new class Routes {
 
   // Here are the "Containers" in our app (e.g. Screens).
@@ -11,14 +14,14 @@ export default new class Routes {
 
   get AllComponentsScreen () {
     return {
-      title: 'Welcome',
+      title: I18n.t('welcome'),
       component: require('../Containers/AllComponentsScreen').default
     }
   }
 
   get LoginScreen () {
     return {
-      title: 'Login',
+      title: I18n.t('login'),
       component: require('../Containers/LoginScreen').default,
       customConfiguration: Transitions.modal,
       rightButton: 'FORGOT_PASSWORD',

--- a/App/Sagas/WeatherSaga.js
+++ b/App/Sagas/WeatherSaga.js
@@ -4,14 +4,23 @@ import R from 'ramda'
 import Types from '../Actions/Types'
 import Actions from '../Actions/Creators'
 
+// I18n
+import I18n from '../I18n/I18n.js'
+
 export function * getWeather (city) {
   const client = Client({ baseUrl: 'http://openweathermap.org/data/2.1' })
   const response = yield call(client.get, 'find/name', { q: city })
   const { ok, json } = response
   if (ok) {
     const kelvin = R.path(['list', 0, 'main', 'temp'], json)
-    const temp = Math.round(((kelvin - 273.15) * 1.8000) + 32)
-    yield put(Actions.receiveTemperature(temp))
+    const celcius = kelvin - 273.15
+    const farenheit = (celcius * 1.8000) + 32
+
+    if (I18n.t('tempIndicator') === 'F') {
+      yield put(Actions.receiveTemperature(Math.round(farenheit)))
+    } else {
+      yield put(Actions.receiveTemperature(Math.round(celcius)))
+    }
   } else {
     yield put(Actions.receiveTemperatureFailure())
   }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -120,6 +120,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-i18n')
     compile project(':react-native-vector-icons')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/rnbase/MainActivity.java
+++ b/android/app/src/main/java/com/rnbase/MainActivity.java
@@ -1,6 +1,7 @@
 package com.rnbase;
 
 import com.facebook.react.ReactActivity;
+import com.i18n.reactnativei18n.ReactNativeI18n;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -36,6 +37,7 @@ public class MainActivity extends ReactActivity {
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
+            new ReactNativeI18n(),
             new VectorIconsPackage()
         );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,3 +3,5 @@ rootProject.name = 'RNBase'
 include ':app'
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
+include ':react-native-i18n'
+project(':react-native-i18n').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-i18n/android')

--- a/ios/RNBase.xcodeproj/project.pbxproj
+++ b/ios/RNBase.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -31,6 +30,7 @@
 		9899EBC86C7D4D898D025410 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EE9C0949165E4E669FB7C472 /* Octicons.ttf */; };
 		B6AA679B9ED84BC98CDD8932 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3D3654AF0EBC4655BD8FEEFB /* MaterialIcons.ttf */; };
 		D1A64356ED20492AA3F40EE5 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 36E9127216354BAAA0AA1492 /* FontAwesome.ttf */; };
+		A427EE71C7CC4E1C95DA919E /* libRNI18n.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B7020FAD6C04DB88066FD95 /* libRNI18n.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -152,6 +152,8 @@
 		B721D5FF6D414F8E8BA82A71 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
 		EE9C0949165E4E669FB7C472 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		F745055AC6594FDE88A42390 /* libRNVectorIcons.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNVectorIcons.a; sourceTree = "<group>"; };
+		BF9A5384DD3846318247BDE8 /* RNI18n.xcodeproj */ = {isa = PBXFileReference; name = "RNI18n.xcodeproj"; path = "../node_modules/react-native-i18n/RNI18n.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		6B7020FAD6C04DB88066FD95 /* libRNI18n.a */ = {isa = PBXFileReference; name = "libRNI18n.a"; path = "libRNI18n.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +179,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				60E66BE4D5434E7BA7EEA39E /* libRNVectorIcons.a in Frameworks */,
+				A427EE71C7CC4E1C95DA919E /* libRNI18n.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -323,6 +326,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				B721D5FF6D414F8E8BA82A71 /* RNVectorIcons.xcodeproj */,
+				BF9A5384DD3846318247BDE8 /* RNI18n.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -659,6 +663,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RNBase.app/RNBase";
@@ -680,6 +685,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RNBase.app/RNBase";
@@ -696,6 +702,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
 				);
 				INFOPLIST_FILE = RNBase/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -713,6 +720,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
 				);
 				INFOPLIST_FILE = RNBase/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -760,6 +768,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -801,6 +810,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^0.14.5",
     "react-native": "^0.22.0",
     "react-native-animatable": "^0.5.2",
+    "react-native-i18n": "0.0.8",
     "react-native-vector-icons": "^1.3.3",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",


### PR DESCRIPTION
### Internationalization (I18n)

I pulled in the `react-native-i18n` project and implemented it. I've got a single file: `/App/I18n/I18n.js` that needs to be required to use the internationalization.

I'm pulling in the `I18n` class, modifying it and adding translations and then passing it back to exports for the file so that instead of something like:

```js
// I18n
import I18n from 'react-native-i18n'
import from '../I18n/I18n.js'
```
You just have to do:

```js
// I18n
import I18n from '../I18n/I18n.js'
```

Let me know if this is not the preferred way, but i thought that one include would be better on every file that uses i18n than two.

### Screenshots:

#### iOS

![simulator screen shot apr 1 2016 3 35](https://cloud.githubusercontent.com/assets/139261/14218218/d1e0f6e2-f820-11e5-8121-1d23bca77bb2.png)

#### Android

<img width="639" alt="screen shot 2016-04-01 at 3 45 18 pm" src="https://cloud.githubusercontent.com/assets/139261/14218225/de25b97e-f820-11e5-9941-3654a30d194b.png">

### Pull-Request Checklist

- [x] Works on iOS/Android/XDE
- [x] Tests Pass
- [x] Code is StandardJS compliant
